### PR TITLE
StatusBarManager.getHeight Android Error

### DIFF
--- a/components/GridImageViewer.js
+++ b/components/GridImageViewer.js
@@ -14,9 +14,11 @@ const GridImageView = ({ data, headers = null }) => {
     const [height, setHeight] = useState(STATUSBAR_HEIGHT);
 
     useEffect(() => {
-        StatusBarManager.getHeight((statusBarHeight) => {
-            setHeight(statusBarHeight.height);
-          });
+        if(Platform.OS === 'ios') {
+            StatusBarManager.getHeight((statusBarHeight) => {
+                setHeight(statusBarHeight.height);
+              });
+        }
     }, []);
 
             

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridimageviewer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridimageviewer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/react-native-grid-image-viewer/components/GridImageViewer.js
+++ b/react-native-grid-image-viewer/components/GridImageViewer.js
@@ -14,9 +14,12 @@ const GridImageView = ({ data, headers = null }) => {
     const [height, setHeight] = useState(STATUSBAR_HEIGHT);
 
     useEffect(() => {
-        StatusBarManager.getHeight((statusBarHeight) => {
-            setHeight(statusBarHeight.height);
-          });
+        if(Platform.OS === 'ios') {
+            StatusBarManager.getHeight((statusBarHeight) => {
+                setHeight(statusBarHeight.height);
+              });
+        }
+        
     }, []);
 
             

--- a/react-native-grid-image-viewer/package.json
+++ b/react-native-grid-image-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-grid-image-viewer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A grid display for multiple images which you can view on clicking in fullscreen mode and swipe through.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Android does not support StatusBarManager.getHeight, thus the package crashes when used on Android. 
<img width="315" alt="Screenshot 2021-03-02 at 5 32 00 PM" src="https://user-images.githubusercontent.com/14024668/109724202-34afd880-7b7d-11eb-86c6-2baab345e1a7.png">
