### PR TITLE
Use FlatList instead of ScrollView for modal

### DIFF
--- a/react-native-grid-image-viewer/components/GridImageViewer.js
+++ b/react-native-grid-image-viewer/components/GridImageViewer.js
@@ -7,7 +7,6 @@ import {
   Modal,
   FlatList,
   Image,
-  ScrollView,
   Platform,
   NativeModules,
 } from 'react-native';
@@ -41,15 +40,16 @@ const GridImageView = ({
 
   const Component = ({style = {flex: 1}}) => {
     return (
-      <ScrollView
+      <FlatList
         showsHorizontalScrollIndicator={false}
         ref={ref}
         style={{...style}}
         snapToInterval={Dimensions.get('window').width}
         decelerationRate="fast"
-        horizontal>
-        {data.map((item, key) => (
-          <View key={key}>
+        horizontal
+        data={data}
+        renderItem={({item, index}) => (
+          <View key={index}>
             {renderModalImage !== null ? (
               renderModalImage(item, {
                 ...styles.img_modal,
@@ -70,8 +70,8 @@ const GridImageView = ({
               />
             )}
           </View>
-        ))}
-      </ScrollView>
+        )}
+      />
     );
   };
 
@@ -92,9 +92,8 @@ const GridImageView = ({
             onPress={() => {
               if (modal.data - 1 >= 0) {
                 setTimeout(() => {
-                  ref.current.scrollTo({
-                    x: Dimensions.get('window').width * (modal.data - 1),
-                    y: 0,
+                  ref.current.scrollToIndex({
+                    index: modal.data - 1,
                     animated: false,
                   });
                 }, 1);
@@ -119,9 +118,8 @@ const GridImageView = ({
             onPress={() => {
               if (modal.data + 1 < data.length) {
                 setTimeout(() => {
-                  ref.current.scrollTo({
-                    x: Dimensions.get('window').width * (modal.data + 1),
-                    y: 0,
+                  ref.current.scrollToIndex({
+                    index: modal.data + 1,
                     animated: false,
                   });
                 }, 1);
@@ -149,9 +147,8 @@ const GridImageView = ({
                       setModal({visible: true, data: index * 3});
 
                       setTimeout(() => {
-                        ref.current.scrollTo({
-                          x: Dimensions.get('window').width * index * 3,
-                          y: 0,
+                        ref.current.scrollToIndex({
+                          index: index * 3,
                           animated: false,
                         });
                       }, 1);
@@ -182,9 +179,8 @@ const GridImageView = ({
                       setModal({visible: true, data: index * 3 + 1});
 
                       setTimeout(() => {
-                        ref.current.scrollTo({
-                          x: Dimensions.get('window').width * (index * 3 + 1),
-                          y: 0,
+                        ref.current.scrollToIndex({
+                          index: index * 3 + 1,
                           animated: false,
                         });
                       }, 1);
@@ -215,9 +211,8 @@ const GridImageView = ({
                       setModal({visible: true, data: index * 3 + 2});
 
                       setTimeout(() => {
-                        ref.current.scrollTo({
-                          x: Dimensions.get('window').width * (index * 3 + 2),
-                          y: 0,
+                        ref.current.scrollToIndex({
+                          index: index * 3 + 2,
                           animated: false,
                         });
                       }, 1);

--- a/react-native-grid-image-viewer/components/GridImageViewer.js
+++ b/react-native-grid-image-viewer/components/GridImageViewer.js
@@ -48,6 +48,11 @@ const GridImageView = ({
         decelerationRate="fast"
         horizontal
         data={data}
+        getItemLayout={(_, index) => ({
+          length: Dimensions.get('window').width,
+          offset: Dimensions.get('window').width * index,
+          index,
+        })}
         renderItem={({item, index}) => (
           <View key={index}>
             {renderModalImage !== null ? (

--- a/react-native-grid-image-viewer/components/GridImageViewer.js
+++ b/react-native-grid-image-viewer/components/GridImageViewer.js
@@ -1,4 +1,4 @@
-import React, {useState, useRef, useEffect} from 'react';
+import React, {useCallback, useState, useRef, useEffect} from 'react';
 import {
   View,
   StyleSheet,
@@ -25,6 +25,17 @@ const GridImageView = ({
   const [modal, setModal] = useState({visible: false, data: 0});
   const ref = useRef();
   var key = 0;
+
+  // Updates modal.data when user scrolls
+  const onViewableItemsChanged = useCallback(
+    ({changed}) => {
+      const viewableItem = changed.find((item) => item.isViewable);
+      if (viewableItem && typeof viewableItem.index === 'number') {
+        setModal({visible: true, data: viewableItem.index});
+      }
+    },
+    [setModal],
+  );
 
   const {StatusBarManager} = NativeModules;
   const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : StatusBarManager.HEIGHT;
@@ -53,6 +64,7 @@ const GridImageView = ({
           offset: Dimensions.get('window').width * index,
           index,
         })}
+        onViewableItemsChanged={onViewableItemsChanged}
         renderItem={({item, index}) => (
           <View key={index}>
             {renderModalImage !== null ? (


### PR DESCRIPTION
Use `FlatList` instead of `ScrollView` for modal to address performance problems with many images.

## Considerations

- Consider adding a `keyExtractor` prop that will allow developers to use a better key for list items.